### PR TITLE
Chrome allow additional options and allow redirecting child output

### DIFF
--- a/lib/es8/Nick.js
+++ b/lib/es8/Nick.js
@@ -156,6 +156,36 @@ class Nick {
 		} else {
 			options.printAborts = true
 		}
+		if (_.has(options, 'childStderr')) {
+			if (typeof options.childStderr !== 'string' || (_.isString(options.childStderr) || !_.includes(['stdout', 'stderr'], options.childStderr))) {
+				throw new TypeError('childStderr option must be of type string and have one of the value: stderr or stdout')
+			}
+		} else {
+			options.childStderr = 'stdout'
+		}
+
+		if (_.has(options, 'childStdout')) {
+			if (typeof options.childStdout !== 'string' || (_.isString(options.childStdout) || !_.includes(['stdout', 'stderr'], options.childStdout))) {
+				throw new TypeError('childStdout option must be of type string and have one of the value: stderr or stdout')
+			}
+		} else {
+			options.childStdout = 'stdout'
+		}
+
+		// additionalChildOptions
+		if (_.has(options, 'additionalChildOptions')) {
+			if ((typeof process !== "undefined") && _.isObject(process) && _.isObject(process.versions) && (typeof process.versions.node === 'string')) {
+				if (!_.isArray(options.additionalChildOptions) || (_.isArray(options.additionalChildOptions) && !_.every(options.additionalChildOptions, _.isString))) {
+					throw new TypeError('additionalChildOptions option must be of type array with string elements')
+				}
+			} else {
+				if (!_.isArray(options.additionalChildOptions) || (_.isArray(options.additionalChildOptions) && !_.every(options.additionalChildOptions, _.isObject))) {
+					throw new TypeError('additionalChildOptions option must be of type array with {} elements')
+				}
+			}
+		} else {
+			options.additionalChildOptions = []
+		}
 
 		// whitelist
 		const whitelist = []

--- a/lib/es8/casper/TabDriver.js
+++ b/lib/es8/casper/TabDriver.js
@@ -22,7 +22,7 @@ class TabDriver {
 		this._onConfirm = null
 		this._onPrompt = null
 
-		const casperOptions = {
+		let casperOptions = {
 			verbose: false,
 			colorizerType: 'Dummy',
 			exitOnError: true,
@@ -46,6 +46,14 @@ class TabDriver {
 		// only set the option if the end user provided it (prevents overriding the --load-images CLI flag)
 		if (_.has(options, 'loadImages')) {
 			casperOptions.pageSettings.loadImages = options.loadImages
+		}
+
+		if (options.additionalChildOptions.length > 0) {
+			casperOptions = _.merge(
+				{},
+				options.additionalChildOptions,
+				casperOptions
+			);
 		}
 
 		this.__casper = casper.create(casperOptions)

--- a/lib/es8/chrome/BrowserDriver.js
+++ b/lib/es8/chrome/BrowserDriver.js
@@ -60,6 +60,10 @@ class BrowserDriver {
 			childOptions.push("--enable-automation") // inform user that the browser is automatically controlled
 		}
 
+		if (this._options.additionalChildOptions) {
+			childOptions.concat(this._options.additionalChildOptions);
+		}
+
 		// chrome doesnt support proxy auth directly, we'll intercept requests and respond to the auth challenges
 		if (this._options.httpProxy) {
 			const { URL } = require("url")
@@ -88,11 +92,22 @@ class BrowserDriver {
 			callback(`could not start chrome: ${err}`) // it's alright, _initialize() is wrapped with once()
 		})
 		if (this._options.debug) {
+			let that = this;
 			child.stdout.on("data", (d) => {
-				process.stdout.write("CHROME STDOUT: " + d.toString())
+				if (that._options.childStdout == 'stdout') {
+					process.stdout.write("CHROME STDOUT: " + d.toString())
+				}
+				else {
+					process.stderr.write("CHROME STDOUT: " + d.toString())
+				}
 			})
 			child.stderr.on("data", (d) => {
-				process.stdout.write("CHROME STDERR: " + d.toString())
+				if (that._options.childStderr == 'stdout') {
+					process.stdout.write("CHROME STDERR: " + d.toString())
+				}
+				else {
+					process.stderr.write("CHROME STDERR: " + d.toString())
+				}
 			})
 			const pidusage = require("pidusage")
 			const logChromeMemory = () => {


### PR DESCRIPTION
- Allow2 additional options to be passed to chrome and Casper 
 I need this functionality to be able to pass these options to chrome 
    '--ignore-certificate-errors',
   '--ignore-urlfetcher-cert-requests'
- Also ability to redirect child output diffrently . I need this because i want child stderr to write to stdout 

Please let me know if any changes are needed. Thank you 